### PR TITLE
Bugfix: cast env var to bool

### DIFF
--- a/src/beheeromgeving/settings.py
+++ b/src/beheeromgeving/settings.py
@@ -352,5 +352,5 @@ DATAPUNT_AUTHZ = {
 }
 
 # App Config
-FEATURE_FLAG_USE_AUTH = os.getenv("FEATURE_FLAG_USE_AUTH", True)
+FEATURE_FLAG_USE_AUTH = env.bool("FEATURE_FLAG_USE_AUTH", True)
 ADMIN_ROLE_NAME = os.getenv("ADMIN_ROLE_NAME", "admin")


### PR DESCRIPTION
the string it may contain is always truthy.
